### PR TITLE
👷 add: ci で build check が動くようにしてみる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+
+      - name: Install pnpm manually
+        run: npm install -g pnpm@9
+
+      - name: Verify pnpm installation
+        run: |
+          if ! pnpm --version; then
+            echo "pnpm is not installed"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Verify node_modules exists
+        run: |
+          if [ ! -d "node_modules" ]; then
+            echo "node_modules not found" && exit 1
+          fi
+
+      - name: Check next version
+        run: |
+          if ! pnpm exec next --version; then
+            echo "next not found"
+            exit 1
+          fi
+
+      - name: Run build
+        run: pnpm exec next build

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 export default function Home() {
   return (
-    <></>
     <>
       <p>hello, world</p>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 export default function Home() {
   return (
+    <></>
     <>
       <p>hello, world</p>
     </>


### PR DESCRIPTION
### ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- https://www.notion.so/issue-Next-js-CI-19ff29acc5a28031b6e9fba322905140
- https://github.com/Kazuki0320/sns-scouter/issues/3

### やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- Next.js のビルドでエラーが出ていないかをチェックする CI を追加しました
  - Varcel のデプロイチェックでも十分ではあるが、Actions 上でも気軽に見たい 
- 簡単解説
  - 環境構築（Check next versionまで）は以下 PR のコピペ
    - https://github.com/Kazuki0320/sns-scouter/pull/9
  - pnpm exec next build により、Next.js のビルドを実施し、コマンドがエラーを吐いたらCIがこける

### 動作確認

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->

- [x] ビルドがこけるようなコードを書くと、CIがこける
  - ローカルでこの状態の時に push
    - ![image](https://github.com/user-attachments/assets/a2a3811a-f478-4d66-b056-549035bd3ed1)
    - ![image](https://github.com/user-attachments/assets/966e8e5b-c1dc-4418-8bcc-48d2e2d55e06)
  - CI がエラーになる
    - ![image](https://github.com/user-attachments/assets/a396e1ed-d520-4a8f-a8e1-e109772ecec8)
    - <img width="1029" alt="スクリーンショット 2025-02-24 12 23 24" src="https://github.com/user-attachments/assets/9b5e079b-c789-4d06-b255-460547e4f6c9" />
    - URL: https://github.com/Kazuki0320/sns-scouter/actions/runs/13489905275/job/37686372918




- [x] ビルドに通ると、CIが成功する
  - URL: https://github.com/Kazuki0320/sns-scouter/actions/runs/13490052917/job/37686767661


### 備考

<!-- その他何かあれば。 -->

- 
