### PR TITLE
formからresultにロード画面を挟んでページ遷移

### DIFF
--- a/src/app/form/page.tsx
+++ b/src/app/form/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
 
 export default function Page() {
-  const router = useRouter();
-
   return (
     <>
       <h2>Form Page</h2>

--- a/src/app/form/page.tsx
+++ b/src/app/form/page.tsx
@@ -1,5 +1,4 @@
-"use client"; // useRouterを使うために必要
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function Page() {
   const router = useRouter();

--- a/src/app/form/page.tsx
+++ b/src/app/form/page.tsx
@@ -1,8 +1,20 @@
+"use client"; // useRouterを使うために必要
+import { useRouter } from "next/navigation";
+
 export default function Page() {
-    return (
-        <>
-            <h2>Form Page</h2>
-            <h3>ここで診断用に必要なフォーム入力があればこのページを使う</h3>
-        </>
-    );
+  const router = useRouter();
+
+  return (
+    <>
+      <h2>Form Page</h2>
+      <h3>ここで診断用に必要なフォーム入力があればこのページを使う</h3>
+      <button
+        onClick={() => {
+          router.push("/result");
+        }}
+      >
+        結果ページへ移動
+      </button>
+    </>
+  );
 }

--- a/src/app/form/page.tsx
+++ b/src/app/form/page.tsx
@@ -7,12 +7,8 @@ export default function Page() {
     <>
       <h2>Form Page</h2>
       <h3>ここで診断用に必要なフォーム入力があればこのページを使う</h3>
-      <button
-        onClick={() => {
-          router.push("/result");
-        }}
-      >
-        結果ページへ移動
+      <button>
+          <Link href={"/result"}>結果ページへ移動</Link>
       </button>
     </>
   );

--- a/src/app/result/loading.tsx
+++ b/src/app/result/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+    return <div>Loading...</div>;
+  }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,8 +1,19 @@
-export default function Page() {
+async function fetchData() {
+    await new Promise((resolve) => setTimeout(resolve, 3000)); // 3秒待つ
+    return {message: "SNSの結果表示"};
+}
+
+export default async function Page() {
+    const data = await fetchData(); // データ取得のシミュレーション
     return (
         <>
             <h2>Result Page</h2>
-            <h3>ここでスカウターの測定結果を表示する。Xへのシェアボタンもここに配置</h3>
+            <h3>
+                ここでスカウターの測定結果を表示する。Xへのシェアボタンもここに配置
+            </h3>
+            <h3>
+                {data.message}
+            </h3>
         </>
     );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,4 +1,5 @@
 async function fetchData() {
+    // NOTE: ローデイング画面を確認するための一時的な処理
     await new Promise((resolve) => setTimeout(resolve, 3000)); // 3秒待つ
     return {message: "SNSの結果表示"};
 }


### PR DESCRIPTION
### ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- streamingの参考 https://nextjs.org/learn/dashboard-app/streaming

### やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- form 画面からresult画面への遷移を行い、result画面が表示されるまでロード画面を表示する

### 動作確認

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->
- 動作確認 https://www.notion.so/DevLab-17af29acc5a280388439f672dc67693c?p=19ff29acc5a280acb768e77cebaba5eb&pm=s


### 備考

<!-- その他何かあれば。 -->

- 
