### PR TITLE
🐛 debug: リザルト画面で ts(18047) エラーが出ていたため、null の場合にメソッドチェーンが走らないように修正 & 少しだけエラーメッセージ周辺で文言やTODOコメントを追加

### DIFF
--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
 
   // TODO: 以下のエラーが発生した時、ユーザーのトップページに戻すための何かしらの処理を考える
   const error =
-    score === null || Number.isNaN(Number(score))
+    score === null || score === '' || Number.isNaN(Number(score))
       ? 'スカウターの測定に失敗しました。もう一度お試しください。'
       : '';
 
@@ -29,7 +29,6 @@ export default function Page() {
   return (
     <>
       <h2>結果</h2>
-      {/* 以下のscoreを、error が true なら出さないようにする */}
       {!error && <h3>{score}</h3>}
       {error && <div className="text-red-500 text-sm">{error}</div>}
       <ShareButton text="test" />

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
 
   const error =
     score === null || Number.isNaN(Number(score))
-      ? '適切な値ではありません'
+      ? 'スカウターの測定に失敗しました。もう一度お試しください。'
       : '';
 
   // NOTE: ローディング画面を一定時間表示するための一時的な処理

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -12,6 +12,7 @@ export default function Page() {
     ? Number(battlePowerResult.get('score'))
     : null;
 
+  // TODO: 以下のエラーが発生した時、ユーザーのトップページに戻すための何かしらの処理を考える
   const error =
     score === null || Number.isNaN(Number(score))
       ? 'スカウターの測定に失敗しました。もう一度お試しください。'

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -10,10 +10,13 @@ export default function Page() {
   const battlePowerResult = useSearchParams();
   const score = Number(battlePowerResult.get('score'));
 
-  const error = score === null || Number.isNaN(Number(score)) ? '適切な値ではありません' : '';
+  const error =
+    score === null || Number.isNaN(Number(score))
+      ? '適切な値ではありません'
+      : '';
 
   // NOTE: ローディング画面を一定時間表示するための一時的な処理
-  useEffect (() => {
+  useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 4000);
     return () => clearTimeout(timer);
   }, []);
@@ -26,11 +29,7 @@ export default function Page() {
     <>
       <h2>結果</h2>
       <h3>{score}</h3>
-      {error && (
-        <div className="text-red-500 text-sm">
-          {error}
-        </div>
-      )}
+      {error && <div className="text-red-500 text-sm">{error}</div>}
       <ShareButton text="test" />
     </>
   );

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -8,7 +8,9 @@ import Loading from './loading';
 export default function Page() {
   const [loading, setLoading] = useState(true);
   const battlePowerResult = useSearchParams();
-  const score = Number(battlePowerResult.get('score'));
+  const score = battlePowerResult
+    ? Number(battlePowerResult.get('score'))
+    : null;
 
   const error =
     score === null || Number.isNaN(Number(score))

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -8,9 +8,7 @@ import Loading from './loading';
 export default function Page() {
   const [loading, setLoading] = useState(true);
   const battlePowerResult = useSearchParams();
-  const score = battlePowerResult
-    ? Number(battlePowerResult.get('score'))
-    : null;
+  const score = battlePowerResult ? battlePowerResult.get('score') : null;
 
   // TODO: 以下のエラーが発生した時、ユーザーのトップページに戻すための何かしらの処理を考える
   const error =
@@ -31,7 +29,8 @@ export default function Page() {
   return (
     <>
       <h2>結果</h2>
-      <h3>{score}</h3>
+      {/* 以下のscoreを、error が true なら出さないようにする */}
+      {!error && <h3>{score}</h3>}
       {error && <div className="text-red-500 text-sm">{error}</div>}
       <ShareButton text="test" />
     </>


### PR DESCRIPTION
### ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- なし

### やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- ts(18047) エラーが出ており、変数 battlePowerResult の型が null を許容する形（ReadonlyURLSearchParams | null）になっていたため、null のときにメソッドチェーンが走らないように変更
##### 実際に発生していたエラー文
```
'battlePowerResult' は 'null' の可能性があります。ts(18047)
const battlePowerResult: ReadonlyURLSearchParams | null
```
![image](https://github.com/user-attachments/assets/9027a6ea-c312-4246-a23c-a83ab9d3af9c)

- ついでに
  - クエリパラメータの値は文字列のままでも表示に影響はないので、数字に変換するのはバリデーションを行うときだけに変更
  - 空文字も意図している動作ではないため、エラーにしておいた
  - エラーメッセージに、ユーザーに何が起きているのかを少しでもわかるように変更
    - 現状エラーが出た時にユーザーが次何をすればいいのかわからない形になっている件について、とりあえず TODO コメントのみ追加

### 動作確認

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->

- [x] [デグレチェック] トップページからスコアを入力した時、正常に処理が完了する
  -  ![image](https://github.com/user-attachments/assets/dea1d70d-7ad9-4bb9-957e-0ab7f78de7b1)


- [x] [挙動変更] URL に直接文字列を入力したとき、余計な文字 NaN などが出ずにエラーメッセージのみが出る
  - ![image](https://github.com/user-attachments/assets/451751e8-368f-4be9-afec-a56ca73d9953)

- [x] [挙動変更] 元はクエリパラメータが空だったら 0 が出ていたが、意図した動作ではないためエラーとしてメッセージを出すようにした
  - Before
    - ![image](https://github.com/user-attachments/assets/d94a47e2-d2de-406c-a58a-b14961a87938)
  - After
    - ![image](https://github.com/user-attachments/assets/df76d0cf-7d1b-46d2-84cb-84927eb5c78f)



### 備考

<!-- その他何かあれば。 -->

- 参考資料
  - ['element' は 'null' の可能性があります。ts(18047) 〜TypeScriptで要素を取得する〜](https://zenn.dev/hiro24/articles/15aa2cb1b9379f)
    - > 式として代入する場合はオプショナルチェイニングが使えないため、ifを使う（補足：条件文でnullはfalseになる）
  - [[ React, TypeScript ] URL クエリパラメータ文字列が数字かどうかを判定する](https://zenn.dev/hironorioka28/articles/459ddf11ff8ac5)
  - [JavaScriptの数値チェックについてハマったのでメモ 忙しい人向け](https://qiita.com/taku-0728/items/329e0bee1c49b7ce7cd1#%E5%BF%99%E3%81%97%E3%81%84%E4%BA%BA%E5%90%91%E3%81%91)
