### PR TITLE
♻️ refactor: Button コンポーネントを使用するとき、createButtonProps を使用する形に変更

### DIFF
--- a/src/app/experiment/page.tsx
+++ b/src/app/experiment/page.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import { Button, createButtonProps } from '@/components/ui/Button';
 
 export default function Page() {
+  const buttonProps = createButtonProps('button', 'Submit', 'lightblue');
 
   return (
     <>
       <h2>Experiment Page</h2>
       <h3>例えば、ここでコンポーネントのボタンを置いて挙動のテストをする</h3>
+      <Button button={buttonProps} />
       <h3>
         例えば、ここでフォロワー数取得のロジックを置いて挙動のテストをする
       </h3>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -26,3 +26,11 @@ export function Button(props: ButtonProps): JSX.Element {
     </>
   );
 }
+
+export function createButtonProps(
+  type: 'submit' | 'reset' | 'button' | undefined,
+  name: string,
+  color: string
+): Button {
+  return { type, name, color };
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,4 @@
-import React, {JSX} from 'react';
+import React, { JSX } from 'react';
 
 type Button = {
   type: 'submit' | 'reset' | 'button' | undefined;
@@ -8,7 +8,7 @@ type Button = {
 
 type ButtonProps = {
   button: Button;
-  onClick?: () => void; 
+  onClick?: () => void;
 };
 
 export function Button(props: ButtonProps): JSX.Element {
@@ -16,7 +16,11 @@ export function Button(props: ButtonProps): JSX.Element {
 
   return (
     <>
-      <button type={button.type} style={{ backgroundColor: button.color }} onClick={onClick}>
+      <button
+        type={button.type}
+        style={{ backgroundColor: button.color }}
+        onClick={onClick}
+      >
         {button.name}
       </button>
     </>

--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -1,5 +1,5 @@
-import React, {JSX} from 'react';
-import { Button } from './Button';
+import React, { JSX } from 'react';
+import { Button, createButtonProps } from './Button';
 
 type ShareButtonProps = {
   tweetText: string;
@@ -9,22 +9,24 @@ export function ShareButton(props: ShareButtonProps): JSX.Element {
   const { tweetText } = props;
 
   function handleShare() {
-    const twitterShareUrl = 'https://x.com/intent/tweet?text=わたしのSNS戦闘力は'+tweetText+'です&hashtags=SNSスカウター';
+    const twitterShareUrl =
+      'https://x.com/intent/tweet?text=わたしのSNS戦闘力は' +
+      tweetText +
+      'です&hashtags=SNSスカウター';
     const newWindow = window.open(twitterShareUrl); // シェアリンクを新しいタブで開く
 
-    if (!newWindow || newWindow.closed || typeof newWindow.closed === 'undefined') {
-      alert('シェアがうまく行えませんでした。申し訳ありませんが、ご自身でシェアをお願いいたします。');
+    if (
+      !newWindow ||
+      newWindow.closed ||
+      typeof newWindow.closed === 'undefined'
+    ) {
+      alert(
+        'シェアがうまく行えませんでした。申し訳ありませんが、ご自身でシェアをお願いいたします。'
+      );
     }
   }
 
-  return (
-    <Button 
-      button={{
-        type:'button',
-        name:'Xでシェアする',
-        color:'Lightblue'
-      }}
-      onClick={handleShare}
-    />
-  );
+  const buttonProps = createButtonProps('button', 'Xでシェアする', 'lightblue');
+
+  return <Button button={buttonProps} onClick={handleShare} />;
 }


### PR DESCRIPTION
### ドキュメント

<!-- Notion のチケットや Figma のデザイン、関連する Slack での議論などの URL を貼る。 -->

- なし

### やったこと

<!-- やったことの概要を端的に書く。細かい話はコードにセルフコメントする。 -->

- 表題まま
- 以下の PR コメントやり取りにて、createButtonProps を使用する形の例示として作成。
  - 問題なければ k-naoyuki のPRにそのまま本PRをマージするか、 k-naoyuki のPRがマージ完了したらこちらの PR を main ブランチにマージします。
- 下でもコメントしましたが、私はファイル保存すると勝手にフォーマットが走るようにしているため、コードの差分としては多く見えてしまうのですが、実態としては createButtonProps を使用する形に変更しただけです〜

### 動作確認

<!-- チェックボックス or 成果物の画像や動画を貼る。 -->

- [x] [デグレチェック] シェアボタンが機能している
- [x] [デグレチェック] コンソールにエラーが出ていない

### 備考

<!-- その他何かあれば。 -->

- 
